### PR TITLE
feat: add snapshot imports and remote artifact downloading support

### DIFF
--- a/ensemble/ensemble.go
+++ b/ensemble/ensemble.go
@@ -280,6 +280,30 @@ func WithSecondaryArtifact(artifactFilePath string) Option {
 	}
 }
 
+// WithSnapshot provides paths to local repository snapshots that will be imported within the Microcks container.
+func WithSnapshot(snapshotFilePath string) Option {
+	return func(e *MicrocksContainersEnsemble) error {
+		e.microcksContainerOptions.Add(microcks.WithSnapshot(snapshotFilePath))
+		return nil
+	}
+}
+
+// WithMainRemoteArtifact provides urls of remote artifacts that will be imported as primary or main ones within the Microcks container.
+func WithMainRemoteArtifact(remoteArtifactUrl string) Option {
+	return func(e *MicrocksContainersEnsemble) error {
+		e.microcksContainerOptions.Add(microcks.WithMainRemoteArtifact(remoteArtifactUrl))
+		return nil
+	}
+}
+
+// WithSecondaryRemoteArtifact provides urls of remote artifacts that will be imported as secondary ones within the Microcks container.
+func WithSecondaryRemoteArtifact(remoteArtifactUrl string) Option {
+	return func(e *MicrocksContainersEnsemble) error {
+		e.microcksContainerOptions.Add(microcks.WithSecondaryRemoteArtifact(remoteArtifactUrl))
+		return nil
+	}
+}
+
 // WithHostAccessPorts helps to open connections between Microcks, Postman or Microcks async
 // to the user's host ports.
 func WithHostAccessPorts(hostAccessPorts []int) Option {

--- a/microcks.go
+++ b/microcks.go
@@ -116,11 +116,11 @@ func WithSnapshot(snapshotFilePath string) testcontainers.CustomizeRequestOption
 }
 
 // WithMainRemoteArtifact provides urls of remote artifacts that will be imported as primary or main ones within the Microcks container.
-func WithMainRemoteArtifact(remoteArtifactUrl string) testcontainers.CustomizeRequestOption {
+func WithMainRemoteArtifact(remoteArtifactUrl string, secretName ...string) testcontainers.CustomizeRequestOption {
 	return func(req *testcontainers.GenericContainerRequest) error {
 		hooks := testcontainers.ContainerLifecycleHooks{
 			PostReadies: []testcontainers.ContainerHook{
-				downloadArtifactHook(remoteArtifactUrl, true),
+				downloadArtifactHook(remoteArtifactUrl, true, secretName...),
 			},
 		}
 		req.LifecycleHooks = append(req.LifecycleHooks, hooks)
@@ -129,11 +129,11 @@ func WithMainRemoteArtifact(remoteArtifactUrl string) testcontainers.CustomizeRe
 }
 
 // WithSecondaryRemoteArtifact provides urls of remote artifacts that will be imported as secondary ones within the Microcks container.
-func WithSecondaryRemoteArtifact(remoteArtifactUrl string) testcontainers.CustomizeRequestOption {
+func WithSecondaryRemoteArtifact(remoteArtifactUrl string, secretName ...string) testcontainers.CustomizeRequestOption {
 	return func(req *testcontainers.GenericContainerRequest) error {
 		hooks := testcontainers.ContainerLifecycleHooks{
 			PostReadies: []testcontainers.ContainerHook{
-				downloadArtifactHook(remoteArtifactUrl, false),
+				downloadArtifactHook(remoteArtifactUrl, false, secretName...),
 			},
 		}
 		req.LifecycleHooks = append(req.LifecycleHooks, hooks)
@@ -335,13 +335,13 @@ func (container *MicrocksContainer) ImportSnapshot(ctx context.Context, snapshot
 }
 
 // DownloadAsMainArtifact downloads a remote artifact as a primary or main one within the Microcks container.
-func (container *MicrocksContainer) DownloadAsMainArtifact(ctx context.Context, remoteArtifactUrl string) (int, error) {
-	return container.downloadArtifact(ctx, remoteArtifactUrl, true)
+func (container *MicrocksContainer) DownloadAsMainArtifact(ctx context.Context, remoteArtifactUrl string, secretName ...string) (int, error) {
+	return container.downloadArtifact(ctx, remoteArtifactUrl, true, secretName...)
 }
 
 // DownloadAsSecondaryArtifact downloads a remote artifact as a secondary one within the Microcks container.
-func (container *MicrocksContainer) DownloadAsSecondaryArtifact(ctx context.Context, remoteArtifactUrl string) (int, error) {
-	return container.downloadArtifact(ctx, remoteArtifactUrl, false)
+func (container *MicrocksContainer) DownloadAsSecondaryArtifact(ctx context.Context, remoteArtifactUrl string, secretName ...string) (int, error) {
+	return container.downloadArtifact(ctx, remoteArtifactUrl, false, secretName...)
 }
 
 // TestEndpoint launches a conformance test on an endpoint.
@@ -618,15 +618,15 @@ func (container *MicrocksContainer) importSnapshot(ctx context.Context, snapshot
 	return response.StatusCode, nil
 }
 
-func downloadArtifactHook(remoteArtifactUrl string, mainArtifact bool) testcontainers.ContainerHook {
+func downloadArtifactHook(remoteArtifactUrl string, mainArtifact bool, secretName ...string) testcontainers.ContainerHook {
 	return func(ctx context.Context, container testcontainers.Container) error {
 		microcksContainer := &MicrocksContainer{Container: container}
-		_, err := microcksContainer.downloadArtifact(ctx, remoteArtifactUrl, mainArtifact)
+		_, err := microcksContainer.downloadArtifact(ctx, remoteArtifactUrl, mainArtifact, secretName...)
 		return err
 	}
 }
 
-func (container *MicrocksContainer) downloadArtifact(ctx context.Context, remoteArtifactUrl string, mainArtifact bool) (int, error) {
+func (container *MicrocksContainer) downloadArtifact(ctx context.Context, remoteArtifactUrl string, mainArtifact bool, secretName ...string) (int, error) {
 	// Retrieve API endpoint.
 	httpEndpoint, err := container.HttpEndpoint(ctx)
 	if err != nil {
@@ -636,6 +636,9 @@ func (container *MicrocksContainer) downloadArtifact(ctx context.Context, remote
 	data := url.Values{}
 	data.Set("url", remoteArtifactUrl)
 	data.Set("mainArtifact", strconv.FormatBool(mainArtifact))
+	if len(secretName) > 0 && len(secretName[0]) > 0 {
+		data.Set("secretName", secretName[0])
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, httpEndpoint+"/api/artifact/download", strings.NewReader(data.Encode()))
 	if err != nil {

--- a/microcks.go
+++ b/microcks.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -99,6 +100,45 @@ func WithMainArtifact(artifactFilePath string) testcontainers.CustomizeRequestOp
 // Once it will be started and healthy.
 func WithSecondaryArtifact(artifactFilePath string) testcontainers.CustomizeRequestOption {
 	return WithArtifact(artifactFilePath, false)
+}
+
+// WithSnapshot provides paths to local repository snapshots that will be imported within the Microcks container.
+func WithSnapshot(snapshotFilePath string) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		hooks := testcontainers.ContainerLifecycleHooks{
+			PostReadies: []testcontainers.ContainerHook{
+				importSnapshotHook(snapshotFilePath),
+			},
+		}
+		req.LifecycleHooks = append(req.LifecycleHooks, hooks)
+		return nil
+	}
+}
+
+// WithMainRemoteArtifact provides urls of remote artifacts that will be imported as primary or main ones within the Microcks container.
+func WithMainRemoteArtifact(remoteArtifactUrl string) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		hooks := testcontainers.ContainerLifecycleHooks{
+			PostReadies: []testcontainers.ContainerHook{
+				downloadArtifactHook(remoteArtifactUrl, true),
+			},
+		}
+		req.LifecycleHooks = append(req.LifecycleHooks, hooks)
+		return nil
+	}
+}
+
+// WithSecondaryRemoteArtifact provides urls of remote artifacts that will be imported as secondary ones within the Microcks container.
+func WithSecondaryRemoteArtifact(remoteArtifactUrl string) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		hooks := testcontainers.ContainerLifecycleHooks{
+			PostReadies: []testcontainers.ContainerHook{
+				downloadArtifactHook(remoteArtifactUrl, false),
+			},
+		}
+		req.LifecycleHooks = append(req.LifecycleHooks, hooks)
+		return nil
+	}
 }
 
 // WithArtifact provides paths to artifacts that will be imported within the Microcks container.
@@ -287,6 +327,21 @@ func (container *MicrocksContainer) ImportAsMainArtifact(ctx context.Context, ar
 // ImportAsSecondaryArtifact imports an artifact as a secondary one within the Microcks container.
 func (container *MicrocksContainer) ImportAsSecondaryArtifact(ctx context.Context, artifactFilePath string) (int, error) {
 	return container.importArtifact(ctx, artifactFilePath, false)
+}
+
+// ImportSnapshot imports a repository snapshot within the Microcks container.
+func (container *MicrocksContainer) ImportSnapshot(ctx context.Context, snapshotFilePath string) (int, error) {
+	return container.importSnapshot(ctx, snapshotFilePath)
+}
+
+// DownloadAsMainArtifact downloads a remote artifact as a primary or main one within the Microcks container.
+func (container *MicrocksContainer) DownloadAsMainArtifact(ctx context.Context, remoteArtifactUrl string) (int, error) {
+	return container.downloadArtifact(ctx, remoteArtifactUrl, true)
+}
+
+// DownloadAsSecondaryArtifact downloads a remote artifact as a secondary one within the Microcks container.
+func (container *MicrocksContainer) DownloadAsSecondaryArtifact(ctx context.Context, remoteArtifactUrl string) (int, error) {
+	return container.downloadArtifact(ctx, remoteArtifactUrl, false)
 }
 
 // TestEndpoint launches a conformance test on an endpoint.
@@ -501,6 +556,105 @@ func (container *MicrocksContainer) importArtifact(ctx context.Context, artifact
 		return 0, err
 	}
 	return response.StatusCode, err
+}
+
+func importSnapshotHook(snapshotFilePath string) testcontainers.ContainerHook {
+	return func(ctx context.Context, container testcontainers.Container) error {
+		microcksContainer := &MicrocksContainer{Container: container}
+		_, err := microcksContainer.importSnapshot(ctx, snapshotFilePath)
+		return err
+	}
+}
+
+func (container *MicrocksContainer) importSnapshot(ctx context.Context, snapshotFilePath string) (int, error) {
+	// Retrieve API endpoint.
+	httpEndpoint, err := container.HttpEndpoint(ctx)
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("error retrieving Microcks API endpoint: %w", err)
+	}
+
+	// Ensure file exists on fs.
+	file, err := os.Open(snapshotFilePath)
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("error opening snapshot file: %w", err)
+	}
+	defer file.Close()
+
+	// Create a multipart request body, reading the file.
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", filepath.Base(snapshotFilePath))
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("error creating multipart form: %w", err)
+	}
+
+	_, err = io.Copy(part, file)
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("error copying file to multipart form: %w", err)
+	}
+
+	err = writer.Close()
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("error closing multipart form: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, httpEndpoint+"/api/import", body)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusCreated && response.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(response.Body)
+		return response.StatusCode, fmt.Errorf("snapshot has not been correctly imported: %s", string(bodyBytes))
+	}
+
+	return response.StatusCode, nil
+}
+
+func downloadArtifactHook(remoteArtifactUrl string, mainArtifact bool) testcontainers.ContainerHook {
+	return func(ctx context.Context, container testcontainers.Container) error {
+		microcksContainer := &MicrocksContainer{Container: container}
+		_, err := microcksContainer.downloadArtifact(ctx, remoteArtifactUrl, mainArtifact)
+		return err
+	}
+}
+
+func (container *MicrocksContainer) downloadArtifact(ctx context.Context, remoteArtifactUrl string, mainArtifact bool) (int, error) {
+	// Retrieve API endpoint.
+	httpEndpoint, err := container.HttpEndpoint(ctx)
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("error retrieving Microcks API endpoint: %w", err)
+	}
+
+	data := url.Values{}
+	data.Set("url", remoteArtifactUrl)
+	data.Set("mainArtifact", strconv.FormatBool(mainArtifact))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, httpEndpoint+"/api/artifact/download", strings.NewReader(data.Encode()))
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusCreated && response.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(response.Body)
+		return response.StatusCode, fmt.Errorf("artifact has not been correctly downloaded: %s", string(bodyBytes))
+	}
+
+	return response.StatusCode, nil
 }
 
 func createSecretHook(s client.Secret) testcontainers.ContainerHook {

--- a/microcks_test.go
+++ b/microcks_test.go
@@ -165,3 +165,54 @@ func TestContractTestingFunctionality(t *testing.T) {
 
 	test.PrintMicrocksContainerLogs(t, ctx, microcksContainer)
 }
+
+func TestRemoteArtifactDownload(t *testing.T) {
+	ctx := context.Background()
+
+	microcksContainer, err := microcks.RunContainer(ctx,
+		testcontainers.WithImage("quay.io/microcks/microcks-uber:nightly"),
+		microcks.WithMainRemoteArtifact("https://raw.githubusercontent.com/microcks/microcks/master/samples/APIPastry-openapi.yaml"),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := microcksContainer.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate container: %s", err)
+		}
+	})
+
+	// Check that mock from main/primary remote artifact has been loaded.
+	pastriesUrl, err := microcksContainer.RestMockEndpoint(ctx, "API Pastry - 2.0", "2.0.0")
+	require.NoError(t, err)
+
+	resp, err := http.Get(pastriesUrl + "/pastry/Millefeuille")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestRemoteArtifactDownloadImperative(t *testing.T) {
+	ctx := context.Background()
+
+	microcksContainer, err := microcks.Run(ctx, "quay.io/microcks/microcks-uber:nightly")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := microcksContainer.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate container: %s", err)
+		}
+	})
+
+	status, err := microcksContainer.DownloadAsMainArtifact(ctx, "https://raw.githubusercontent.com/microcks/microcks/master/samples/APIPastry-openapi.yaml")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, status)
+
+	// Check that mock from main/primary remote artifact has been loaded.
+	pastriesUrl, err := microcksContainer.RestMockEndpoint(ctx, "API Pastry - 2.0", "2.0.0")
+	require.NoError(t, err)
+
+	resp, err := http.Get(pastriesUrl + "/pastry/Millefeuille")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}


### PR DESCRIPTION
### Description
This PR brings the `microcks-testcontainers-go` module up to feature parity with the Node.js implementation by introducing support for Snapshot Imports and Remote Artifact Downloading. 

Go developers can now seamlessly bootstrap their testcontainers using a pre-configured database snapshot or fetch remote OpenAPI/Postman artifacts without having to download them locally prior to running their test suites.

Fixs : #193 


### Changes Made
- **Snapshot Imports (`microcks.go`)**: 
  - Added `WithSnapshot(snapshotFilePath)` hook for container startup.
  - Added `ImportSnapshot(ctx, snapshotFilePath)` for imperative imports.
- **Remote Artifacts (`microcks.go`)**:
  - Added `WithMainRemoteArtifact(url)` and `WithSecondaryRemoteArtifact(url)` hooks for container startup.
  - Added `DownloadAsMainArtifact(ctx, url)` and `DownloadAsSecondaryArtifact(ctx, url)` for imperative downloads.
- **Ensemble Support (`ensemble/ensemble.go`)**:
  - Exposed `WithSnapshot`, `WithMainRemoteArtifact`, and `WithSecondaryRemoteArtifact` as valid `Option` types for the `MicrocksContainersEnsemble`.
- **Tests (`microcks_test.go`)**: 
  - Added `TestRemoteArtifactDownload` and `TestRemoteArtifactDownloadImperative` to verify that the container correctly downloads remote artifacts and exposes the relevant mock endpoints.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?
- [x] Ran `go test ./...` in the `microcks-testcontainers-go` module to ensure all new and existing tests pass.

